### PR TITLE
Improvement/first fetch css

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -40,3 +40,22 @@ a {
     color-scheme: dark;
   }
 }
+.loader {
+  width: 48px;
+  height: 48px;
+  border: 5px solid #FFF;
+  border-bottom-color: #4f46e5;
+  border-radius: 50%;
+  display: inline-block;
+  box-sizing: border-box;
+  animation: rotation 1s linear infinite;
+}
+
+@keyframes rotation {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -51,12 +51,15 @@ export default function Home() {
         />
         <LogoutButton />
         {isPreviewVisible && (
-          <Preview
-            inputs={inputs}
-            imageUrl={imageUrl}
-            selectedTemplate={selectedTemplate}
-            cssContents={cssContents}
-          />
+          <div style={{ flex: 1, padding: '20px', backgroundColor: '#e9ecef', overflow: 'auto' }}>
+            <h2 style={{ textAlign: 'center', color: '#495057' }}>プレビュー</h2>
+            <Preview
+              inputs={inputs}
+              imageUrl={imageUrl}
+              selectedTemplate={selectedTemplate}
+              cssContents={cssContents}
+            />
+          </div>
         )}
       </div>
     </RequireLogin>

--- a/src/components/Preview.tsx
+++ b/src/components/Preview.tsx
@@ -21,7 +21,11 @@ const Preview: React.FC<PreviewProps> = React.memo(({
   const css = cssContents[selectedTemplate] || '';
 
   if (!TemplateComponent || !css) {
-    return <div>Loading Preview...</div>;
+    return (
+      <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', minHeight: '600px', width: '100%' }}>
+        <div className="loader"></div>
+      </div>
+    );
   }
 
   return (

--- a/src/components/Preview.tsx
+++ b/src/components/Preview.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import React from 'react';
 import { templates, TemplateKey } from '@/lib/templates';
 import { Inputs } from '@/types/portfolio';
 
@@ -10,7 +11,7 @@ interface PreviewProps {
   cssContents: Record<string, string>;
 }
 
-const Preview: React.FC<PreviewProps> = ({
+const Preview: React.FC<PreviewProps> = React.memo(({
   inputs,
   imageUrl,
   selectedTemplate,
@@ -19,23 +20,17 @@ const Preview: React.FC<PreviewProps> = ({
   const TemplateComponent = templates[selectedTemplate].component;
   const css = cssContents[selectedTemplate] || '';
 
-  // Render null or a loading indicator if the component or css is not ready
   if (!TemplateComponent || !css) {
-    return (
-      <div style={{ flex: 1, padding: '20px', backgroundColor: '#e9ecef', display: 'flex', justifyContent: 'center', alignItems: 'center' }}>
-        <div>Loading Preview...</div>
-      </div>
-    );
+    return <div>Loading Preview...</div>;
   }
 
   return (
-    <div style={{ flex: 1, padding: '20px', backgroundColor: '#e9ecef', overflow: 'auto' }}>
-      <h2 style={{ textAlign: 'center', color: '#495057' }}>プレビュー</h2>
-      <div style={{ backgroundColor: '#fff', border: '1px solid #ccc', borderRadius: '8px', padding: '20px' }}>
-        <TemplateComponent inputs={inputs} imageUrl={imageUrl} css={css} />
-      </div>
+    <div style={{ backgroundColor: '#fff', border: '1px solid #ccc', borderRadius: '8px', padding: '20px' }}>
+      <TemplateComponent inputs={inputs} imageUrl={imageUrl} css={css} />
     </div>
   );
-};
+});
+
+Preview.displayName = 'Preview';
 
 export default Preview;

--- a/src/hooks/usePortfolioManager.ts
+++ b/src/hooks/usePortfolioManager.ts
@@ -86,18 +86,25 @@ export const usePortfolioManager = () => {
   useEffect(() => {
     const cssId = 'portfolio-style';
 
-    // Remove previous style
+    // Get existing link element (will be removed after new one loads)
     const existingLink = document.getElementById(cssId);
-    if (existingLink) {
-      document.head.removeChild(existingLink);
-    }
 
-    // Add new style
+    // Add new style with temporary ID to avoid conflicts
     const path = templates[selectedTemplate].cssPath;
     const link = document.createElement('link');
-    link.id = cssId;
+    link.id = cssId + '-new';
     link.rel = 'stylesheet';
     link.href = path;
+    
+    // Remove old stylesheet only after new one has loaded to prevent FOUC
+    link.onload = () => {
+      if (existingLink && existingLink.parentNode) {
+        existingLink.parentNode.removeChild(existingLink);
+      }
+      // Update the ID after removing old link
+      link.id = cssId;
+    };
+    
     document.head.appendChild(link);
 
     // Fetch and store CSS content for download if not already cached

--- a/src/hooks/usePortfolioManager.ts
+++ b/src/hooks/usePortfolioManager.ts
@@ -115,6 +115,12 @@ export const usePortfolioManager = () => {
       };
       fetchCss();
     }
+    return () => {
+      const linkToRemove = document.getElementById(cssId);
+      if (linkToRemove) {
+        document.head.removeChild(linkToRemove);
+      }
+    };
   }, [selectedTemplate]);
 
   const handleSave = async () => {

--- a/src/hooks/usePortfolioManager.ts
+++ b/src/hooks/usePortfolioManager.ts
@@ -84,23 +84,38 @@ export const usePortfolioManager = () => {
   }, [status, session]);
 
   useEffect(() => {
-    const fetchAllCss = async () => {
-      const allCss: Record<string, string> = {};
-      for (const key in templates) {
-        const path = templates[key as TemplateKey].cssPath;
+    const cssId = 'portfolio-style';
+
+    // Remove previous style
+    const existingLink = document.getElementById(cssId);
+    if (existingLink) {
+      document.head.removeChild(existingLink);
+    }
+
+    // Add new style
+    const path = templates[selectedTemplate].cssPath;
+    const link = document.createElement('link');
+    link.id = cssId;
+    link.rel = 'stylesheet';
+    link.href = path;
+    document.head.appendChild(link);
+
+    // Fetch and store CSS content for download if not already cached
+    if (!cssContents[selectedTemplate]) {
+      const fetchCss = async () => {
         try {
           const response = await fetch(path);
           if (response.ok) {
-            allCss[key] = await response.text();
+            const text = await response.text();
+            setCssContents(prev => ({ ...prev, [selectedTemplate]: text }));
           }
         } catch (error) {
-          console.error(`Failed to fetch css for ${key}:`, error);
+          console.error(`Failed to fetch css for ${selectedTemplate}:`, error);
         }
-      }
-      setCssContents(allCss);
-    };
-    fetchAllCss();
-  }, []);
+      };
+      fetchCss();
+    }
+  }, [selectedTemplate, cssContents]);
 
   const handleSave = async () => {
     if (!session) {

--- a/src/hooks/usePortfolioManager.ts
+++ b/src/hooks/usePortfolioManager.ts
@@ -115,7 +115,7 @@ export const usePortfolioManager = () => {
       };
       fetchCss();
     }
-  }, [selectedTemplate, cssContents]);
+  }, [selectedTemplate]);
 
   const handleSave = async () => {
     if (!session) {

--- a/src/hooks/usePortfolioManager.ts
+++ b/src/hooks/usePortfolioManager.ts
@@ -99,9 +99,7 @@ export const usePortfolioManager = () => {
     
     const handleStylesheetReady = () => {
       if (isCancelled) return;
-      if (existingLink && existingLink.parentNode) {
-        existingLink.parentNode.removeChild(existingLink);
-      }
+      existingLink?.remove();
       // Update the ID after removing old link
       link.id = cssId;
     };
@@ -135,6 +133,10 @@ export const usePortfolioManager = () => {
       isCancelled = true;
       link.onload = null;
       link.onerror = null;
+      // Remove the link element if it was added but hasn't loaded yet
+      if (link.parentNode && link.id !== cssId) {
+        link.remove();
+      }
     };
   }, [selectedTemplate]);
 


### PR DESCRIPTION
一括テンプレート読み込みにより初回のロード時間が長くなる問題を解決

テンプレート選択時に個別に読み込むように変更
1度読み込んだテンプレートはキャッシュに保存されるように変更

ローディングスピナーをcssベースに変更することで、レイアウト崩れを阻止